### PR TITLE
comment-logger: Collapse log output by default

### DIFF
--- a/comment-logger/index.js
+++ b/comment-logger/index.js
@@ -81,10 +81,12 @@ module.exports = function (context, data) {
                     owner: data.repository.owner.login,
                     repo: data.repository.name,
                     number: pull_request,
-                    body: 'The context from the [Jenkins Pipeline run](' + target_url + ') is:\n' +
+                    body: 'Build failed; the context from the [latest run](' + target_url + ') is:\n' +
+                            '<details><summary>Expand to view</summary>\n\n' + // Extra newline required within <details> tag
                             '```\n' +
                             lines.join('\n') +
                             '\n```\n' +
+                            '</details>\n' +
                             '[Powered by the Comment Logger](https://github.com/jenkins-infra/community-functions/tree/master/comment-logger)'
             });
 

--- a/comment-logger/index.js
+++ b/comment-logger/index.js
@@ -81,9 +81,11 @@ module.exports = function (context, data) {
                     owner: data.repository.owner.login,
                     repo: data.repository.name,
                     number: pull_request,
-                    body: 'The context from the [Jenkins Pipeline run](' + target_url + ') is:\n```\n'
-                            + lines.join('\n') + '\n```\n' +
-                            '[powered by the Comment Logger](https://github.com/jenkins-infra/community-functions/tree/master/comment-logger)'
+                    body: 'The context from the [Jenkins Pipeline run](' + target_url + ') is:\n' +
+                            '```\n' +
+                            lines.join('\n') +
+                            '\n```\n' +
+                            '[Powered by the Comment Logger](https://github.com/jenkins-infra/community-functions/tree/master/comment-logger)'
             });
 
             context.done();


### PR DESCRIPTION
Builds (unfortunately) fail often, and so PR pages can end up being pretty long.
This change uses GitHub's `<details>` feature to collapse the log output by default.

Example, collapsed:
![image](https://user-images.githubusercontent.com/138615/35817486-ca23823a-0a9d-11e8-9790-067bd3f87036.png)

Example, after clicking on the wee expand icon:
![image](https://user-images.githubusercontent.com/138615/35817481-c61999d6-0a9d-11e8-84ce-2c5fa84e93d7.png)