### PR TITLE
comment-logger: Unbreak trailing link.

### DIFF
--- a/comment-logger/index.js
+++ b/comment-logger/index.js
@@ -86,7 +86,7 @@ module.exports = function (context, data) {
                             '```\n' +
                             lines.join('\n') +
                             '\n```\n' +
-                            '</details>\n' +
+                            '</details>\n\n' + // Extra newline required after, too
                             '[Powered by the Comment Logger](https://github.com/jenkins-infra/community-functions/tree/master/comment-logger)'
             });
 


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins.io/pull/1367#issuecomment-363174800 shows that the updated layout borked the link at the bottom.