### PR TITLE
[WiP] Lack of JENKINS-50777 metadata should not be fatal

### DIFF
--- a/incrementals-publisher/index.js
+++ b/incrementals-publisher/index.js
@@ -83,7 +83,11 @@ module.exports = async (context, data) => {
 
   if (!buildMetadataParsed.hash) {
     context.log.error('Unable to retrieve a hash or pullHash', buildMetadataJSON);
-    return failRequest(context, 'Unable to retrieve a hash or pullHash');
+    context.res = {
+      status: 200,
+      body: 'Did not find a Git commit hash associated with this build. Some plugins on ' + JENKINS_HOST + ' may not yet have been updated with JENKINS-50777 REST API enhancements. Skipping deployment.\n'
+    };
+    return;
   }
 
   let folderMetadata = await fetch(process.env.FOLDER_METADATA_URL || pipeline.getFolderApiUrl(buildUrl), jenkinsOpts);


### PR DESCRIPTION
Amends #8 until @MarkEWaite releases https://github.com/jenkinsci/git-plugin/pull/581 and we update to that release (or a snapshot/incremental version thereof) so that `master` builds like [this one](https://ci.jenkins.io/job/Core/job/jenkins/job/master/888/) are not treated as failures just because we could not deploy to Incrementals from them.