### PR TITLE
Set a directory URL for the GitHub deployment status

### DIFF
--- a/incrementals-publisher/index.js
+++ b/incrementals-publisher/index.js
@@ -201,6 +201,6 @@ module.exports = async (context, data) => {
     body: 'Response from Artifactory: ' + upload.statusText + '\n'
   };
 
-  const result = await github.createStatus(folderMetadataParsed.owner, folderMetadataParsed.repo, buildMetadataParsed.hash, pomURL);
+  const result = await github.createStatus(folderMetadataParsed.owner, folderMetadataParsed.repo, buildMetadataParsed.hash, pomURL.replace(/[^/]+$/, ''));
   context.log.info('Tried to create GitHub status', result);
 };


### PR DESCRIPTION
Rather than linking to, say, https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-basic-steps/2.8-rc348.c9d28b05698a/workflow-basic-steps-2.8-rc348.c9d28b05698a.pom this will link to its parent https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-basic-steps/2.8-rc348.c9d28b05698a/ which lets you browse the contents, more friendly.

(If there are artifacts being deployed under different GAs, we are displaying just one representive one, not necessarily the most important.)