### PR TITLE
[INFRA-1747] Diagnose a missing or incomplete <scm> section in the POM

### DIFF
--- a/incrementals-publisher/README.adoc
+++ b/incrementals-publisher/README.adoc
@@ -33,7 +33,7 @@ defaults to
 `https://ci.jenkins.io/job/Infra/job/repository-permissions-updater/job/master/lastSuccessfulBuild/artifact/json/github.index.json`
 
 | `JENKINS_AUTH`
-| A `username:password` or `username:apiToken` authentication to Jenkins. Optional.
+| A `username:password` or `username:apiToken` authentication to Jenkins. link:https://ci.jenkins.io/me/configure[API Token]
 
 |===
 

--- a/incrementals-publisher/lib/permissions.js
+++ b/incrementals-publisher/lib/permissions.js
@@ -38,8 +38,17 @@ module.exports = {
         if (entry.name.endsWith('.pom')) {
           const pomXml = zip.entryDataSync(entry.name);
           xml2js.parseString(pomXml, (err, result) => {
+            if (!result.project.scm) {
+              reject(util.format('Missing <scm> section in %s', entry.name));
+            }
             const scm = result.project.scm[0];
+            if (!scm.url) {
+              reject(util.format('Missing <url> section in <scm> of %s', entry.name));
+            }
             const url = scm.url[0];
+            if (!scm.tag) {
+              reject(util.format('Missing <tag> section in <scm> of %s', entry.name));
+            }
             const tag = scm.tag[0];
             const groupId = result.project.groupId[0];
             const artifactId = result.project.artifactId[0];


### PR DESCRIPTION
[INFRA-1747](https://issues.jenkins-ci.org/browse/INFRA-1747)

Tested against https://github.com/jenkinsci/pipeline-log-fluentd-cloudwatch-plugin/pull/5 before I got

```
…
Downloaded https://ci.jenkins.io/job/Plugins/job/pipeline-log-fluentd-cloudwatch-plugin/job/PR-5/7/artifact/**/*-rc*.8150c41b73fd/*-rc*.8150c41b73fd*/*zip*/archive.zip /tmp/incrementals-nwuSfm/archive.zip
Downloaded file size 2160540
System.Private.CoreLib: Exception while executing function: Functions.incrementals-publisher. System.Private.CoreLib: Result: 
Exception: ZIP error: TypeError: Cannot read property '0' of undefined
Stack: .

Executed 'Functions.incrementals-publisher' (Failed, Id=ac745790-3b37-4b24-9658-3b14ebc067ef)
System.Private.CoreLib: Exception while executing function: Functions.incrementals-publisher. System.Private.CoreLib: Result: 
Exception: ZIP error: TypeError: Cannot read property '0' of undefined
Stack: .
```

as observed. After I got

```
…
Downloaded https://ci.jenkins.io/job/Plugins/job/pipeline-log-fluentd-cloudwatch-plugin/job/PR-5/7/artifact/**/*-rc*.8150c41b73fd/*-rc*.8150c41b73fd*/*zip*/archive.zip /tmp/incrementals-YWpwXm/archive.zip
Downloaded file size 2160540
System.Private.CoreLib: Exception while executing function: Functions.incrementals-publisher. System.Private.CoreLib: Result: 
Exception: Missing <url> section in <scm> of io/jenkins/plugins/pipeline-log-fluentd-cloudwatch/1.0-rc35.8150c41b73fd/pipeline-log-fluentd-cloudwatch-1.0-rc35.8150c41b73fd.pom
Stack: .

Executed 'Functions.incrementals-publisher' (Failed, Id=3f24db32-5145-4a3f-89f3-3083a5d5a49e)
System.Private.CoreLib: Exception while executing function: Functions.incrementals-publisher. System.Private.CoreLib: Result: 
Exception: Missing <url> section in <scm> of io/jenkins/plugins/pipeline-log-fluentd-cloudwatch/1.0-rc35.8150c41b73fd/pipeline-log-fluentd-cloudwatch-1.0-rc35.8150c41b73fd.pom
Stack: .
```

which is an improvement at least for the admin. Unfortunately there is still nothing in the `curl -i` output:

```
HTTP/1.1 500 Internal Server Error
Date: Mon, 20 Aug 2018 14:35:35 GMT
Server: Kestrel
Content-Length: 0
```

so while https://github.com/jenkins-infra/pipeline-library/pull/73 would at least alert the developer that something was broken, they will not see what. As usual, something is wrong with how promises are being handled in Node, but I cannot figure out what.