### PR TITLE
Accommodate plugins defining a custom changelist.format

### DIFF
--- a/incrementals-publisher/lib/pipeline.js
+++ b/incrementals-publisher/lib/pipeline.js
@@ -65,6 +65,6 @@ module.exports = {
    */
   getArchiveUrl: (build_url, hash) => {
     let shortHash = hash.substring(0, 12);
-    return build_url + 'artifact/**/*-rc*.' + shortHash + '/*-rc*.' + shortHash + '*/*zip*/archive.zip';
+    return build_url + 'artifact/**/*.' + shortHash + '/*.' + shortHash + '*/*zip*/archive.zip';
   }
 };


### PR DESCRIPTION
https://github.com/jenkinsci/incrementals-tools/pull/14 means that the `-rc` infix is not necessarily present. For example https://ci.jenkins.io/job/Plugins/job/log-cli-plugin/job/PR-18/1/artifact/**/*-rc*.683362379f15/*-rc*.683362379f15*/*zip*/archive.zip is empty but https://ci.jenkins.io/job/Plugins/job/log-cli-plugin/job/PR-18/1/artifact/**/*.683362379f15/*.683362379f15*/*zip*/archive.zip has the expected contents.

@rtyler @daniel-beck @oleg-nenashev